### PR TITLE
Start draft Maintenance section

### DIFF
--- a/05-community-development.Rmd
+++ b/05-community-development.Rmd
@@ -1,6 +1,4 @@
-# Community development
-
-## Roles
+# Community development roles
 
 Our lessons are intended to be teachable by any certified
 Carpentries Instructor with the appropriate domain experience
@@ -12,7 +10,7 @@ at differnt institutions around the world who work together
 in different roles to create, test, and iteratively improve and
 update lesson materials. 
 
-### Lesson Authors
+## Lesson Authors
 
 A lesson may have one or several initial authors. Authors draft
 the lesson content, figures, and code and create appropriate challenge problems. Authors should have both appropriate domain
@@ -32,7 +30,7 @@ author per episode. Clearly defining the learning objectives for each episode
 will help avoid overlap and ensure the lesson flows smoothly - but it will
 still be important to have regular checkins with all authors. 
 
-### Reviewers
+## Reviewers
 
 No one is perfect! Lesson materials should be read and tested by at least
 one person other than the original author before being released for use by the broader community in beta pilot workshops. 
@@ -68,7 +66,7 @@ area. Ensuring that lessons are reviewed by people from a variety of cultural an
 contexts helps us to avoid colloquialisms, culturally-specific references, and other issues that might make our lessons less accessible to a global community. You will likely need one or two reviewers for every
 two hours of lesson content. A four-hour (half day) lesson should have at least two to four reviewers.
 
-### Lesson Maintainers
+## Lesson Maintainers
 
 Lesson Maintainers are essential for the long-term viability of a lesson. As a
 lesson is taught, new Instructors and learners identify potential places
@@ -89,7 +87,7 @@ lesson will have at least two Maintainers, and it's ok for one Maintainer
 to have domain experience and another to be more comfortable with the technical
 aspects of lesson maintainence. 
 
-#### Maintainer recruitment, requirements and time commitment
+### Maintainer recruitment, requirements and time commitment
 
 It's a good idea to recruit at least four Maintainers per lesson, as our
 community members are volunteers and may have fluxuating levels of time to
@@ -120,7 +118,7 @@ A lesson should have at least three onboarded Maintainers before it enters the
 beta pilot workshop phase. Before that time, lesson feedback and edits will generally be 
 managed by the lesson authors.
 
-### Curriculum Advisors
+## Curriculum Advisors
 
 Curriculum Advisors provide high-level oversight, vision, and leadership for a
 curriculum and guide large-scale updates. Unlike Maintainers, who are responsible
@@ -165,7 +163,7 @@ must be a Curriculum Advisory Committee in place at the time of
 its first publication. The CAC must should regularly for as long as a curriculum
 remains active. 
 
-### Beta Pilot Instructors
+## Beta Pilot Instructors
 
 A new lesson or curriculum is often taught for the first time locally at 
 the organization that houses the lesson authors. This can be an opportunity 
@@ -191,7 +189,7 @@ to maturity. For two beta pilot workshops, you will need at least four instructo
 authors should plan to meet virtually with pilot instructors before the workshop to
 answer questions and provide any technical help with setup. 
 
-### Instructors
+## Instructors
 
 Carpentries lessons are designed to be teachable by any certified Instructor with the
 appropriate domain experience. In many cases, there will already be Instructors with
@@ -208,7 +206,7 @@ If your lesson reaches a new domain which isn't well represented in The Carpentr
 and you would like to build capacity for teaching your lessons within The Carpentries, get in 
 touch with team@carpentries.org.
 
-### Summary
+## Summary
 
 | Role | Number needed | When needed |
 |------| ------------- | ----------- |

--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -197,12 +197,15 @@ After a few iterations of teaching and integrating feedback (and at least 2 earl
 
 During this process, you will have the possibility to include a short paper describing your lesson in the GitHub repository and have your lesson considered for publication in [JOSE](http://jose.theoj.org/), the Journal of Open Science Education. Once your lesson has gone through the peer-review process and has been approved by the Editor, we will create an official Zenodo release for it, and the lesson will enter the "Beta" stage.
 
-## The stable lesson
+## The Stable Lesson: Maintenance and lesson releases
 
-TBA
-
-
-## Notes
+- How often to do releases
+  * Maintenance releases, as needed but at least every 3 months
+  * Big releases, once a year
+- How to coordinate lesson releases
+- How to communicate with Maintainers and community about lesson releases
+- How to split development and production
+- How to welcome and onboard new contributors, contributor guidelines
 
 * Announcements 
   - letting the community know that the lesson is being prepared for release and what that means
@@ -218,6 +221,7 @@ TBA
 * How to communicate about a release
 * How to do the release in Zenodo
 * Move on website to different category
+
 ----
 
 [discuss]: https://carpentries.topicbox.com/groups/discuss

--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -197,7 +197,39 @@ After a few iterations of teaching and integrating feedback (and at least 2 earl
 
 During this process, you will have the possibility to include a short paper describing your lesson in the GitHub repository and have your lesson considered for publication in [JOSE](http://jose.theoj.org/), the Journal of Open Science Education. Once your lesson has gone through the peer-review process and has been approved by the Editor, we will create an official Zenodo release for it, and the lesson will enter the "Beta" stage.
 
-## The Stable Lesson: Maintenance and lesson releases
+## The stable lesson: Maintenance and lesson releases
+
+Congratulations! Your lesson has now been published and is being actively taught by the community. 
+That means you're done, right? Not exactly. In order to ensure that your wonderful lesson materials 
+continue to be relevant and useful, you'll need to build and train a team of lesson Maintainers, who 
+are responsible for day-to-day upkeep and periodic publication of the lesson. 
+
+In a [previous chapter](community-development-roles#lesson-maintainers), we discussed the process for recruiting and training Maintainers. Here, we 
+will focus on the responsibilities of Maintainers, their day-to-day workflow, and their involvement
+in the lesson release process. 
+
+As your lesson is taught, workshop instructors and helpers will post issues and pull requests to 
+the lesson's GitHub repository. These will range from typo corrections, to installation problems, 
+to recommendations for changing the libraries or function calls demonstrated in the lesson, and will
+therefore require different levels of consideration and technical expertise to implement. A typo
+correction will probably be taken care of independetly by a single Maintainer, 
+while a proposal to change
+the plotting system used in the lesson from matplotlib to seaborn will require significant 
+discussion. Each lesson Maintainer team will develop their own strategies for managing their work, 
+but we recommend the following as a starting point. 
+
+
+* One Maintainer commits to monitor the repo daily and respond to new issues and PRs to acknowledge them,
+thank the contributor, and apply appropriate [issue tags]().
+* Once a week, one Maintainer looks at the list of active issues and PRs and assigns each to one
+Maintainer team member, based on the time commitment and availability discussed at that month's meeting.
+* Individual Maintainers 
+* something about how to decide whether to implement an issue themselves or ask for a community member to put in a PR
+* the maintainer guidelines that Peter and some others are working on with timelines for closing
+stale things
+* template language in common circumstances - e.g. acknowledging new issues and PRs, turning down/closing a proposal, notice of timeline for considering the proposal, asking proposer to put in a PR, etc
+* All Maintainers for a lesson get together via video-conference once a month to discuss larger proposals
+and agree on the following month's duty roster. 
 
 - How often to do releases
   * Maintenance releases, as needed but at least every 3 months

--- a/10-maintenance.Rmd
+++ b/10-maintenance.Rmd
@@ -1,9 +1,0 @@
-# Maintenance
-
-- How often to do releases
-  * Maintenance releases, as needed but at least every 3 months
-  * Big releases, once a year
-- How to coordinate lesson releases
-- How to communicate with Maintainers and community about lesson releases
-- How to split development and production
-- How to welcome and onboard new contributors, contributor guidelines


### PR DESCRIPTION
This PR:
- Moves bullet points from Maintenance chapter outline to the Lesson life-cycle chapter as a new section titled "The stable lesson: Maintenance and lesson releases" 
- Adds a few paragraphs of content and introduction to the "The stable lesson: Maintenance and lesson releases" section 
- Removes empty Maintenance chapter
- Changes heading hierarchy in Community Development chapter to make TOC informative and renames that chapter to "Community Development Roles"