### PR TITLE
add link to view the page's source file

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -7,6 +7,7 @@ bookdown::gitbook:
       after: |
         <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
     edit: https://github.com/carpentries/curriculum-development/edit/master/%s
+    view: https://github.com/carpentries/curriculum-development/blob/master/%s
     download: ["pdf", "epub"]
 bookdown::pdf_book:
   includes:


### PR DESCRIPTION
Fixes #21 

This should add a link to the header of each page, allowing the reader to view the source file on this repository