### PR TITLE
Add lesson topic info/guidance

### DIFF
--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -4,21 +4,21 @@
 
 This chapter focuses on lessons that are being developed
 with the intention of becoming officially supported
-Carpentries lessons within an existing Lesson Program. 
+Carpentries lessons within an existing Lesson Program.
 Lessons being developed for unofficial community use
-may go through some or all of the stages discussed here, 
-at the discretion of the lesson's authors. Materials 
+may go through some or all of the stages discussed here,
+at the discretion of the lesson's authors. Materials
 intended to become part of a **new** Lesson Program
-must meet additional requirements as described in 
+must meet additional requirements as described in
 the [Lesson Programs][lesson-programs] section of
-The Carpentries Handbook. 
+The Carpentries Handbook.
 
 ## Overview and definitions
 
-Before being adopted as an official Carpentries lesson, 
+Before being adopted as an official Carpentries lesson,
 new lessons go through a series of stages designed to
 ensure they are sufficiently documented to be teachable
-by instructors outside of the initial author group. 
+by instructors outside of the initial author group.
 
 In brief: the **pre-alpha** and **alpha** stages focus on
 developing the lesson content, while the **beta** stage
@@ -30,7 +30,7 @@ include_svg("figures/release_timeline.svg")
 ```
 
 Lessons start in the **pre-alpha** stage - this stage
-encompasses everything from the initial lesson idea 
+encompasses everything from the initial lesson idea
 through the first time the lesson is taught. This
 first draft is usually written by an individual
 or a small group of people. From this first draft, the
@@ -39,21 +39,21 @@ their home organisation, and collect and incorporate
 feedback from learners and co-instructors. They go
 through this iterative process a few times to bring the
 lesson to where it is ready to be taught by other
-members of The Carpentries community. 
+members of The Carpentries community.
 
 When it is ready for broader teaching and contributions,
-the lesson is published for 
+the lesson is published for
 the first time on Zenodo and is now in the **beta**
 stage. The Carpentries staff will assist the lesson
-authors in organising **beta pilots**. 
+authors in organising **beta pilots**.
 **Beta pilots**
-should be hosted at a different organisation, and 
-ideally in a different country than the alpha pilots. 
+should be hosted at a different organisation, and
+ideally in a different country than the alpha pilots.
 There are generally two or three beta pilots over a
 period of six months.
 
 After beta pilots, the lesson authors and Maintainers
-incorporate feedback and produce a polished version of 
+incorporate feedback and produce a polished version of
 the lesson. It is now mature enough and
 documented enough so that anyone interested can teach it. The lesson is published on [Zenodo][zenodo] and listed on the
 Lessons page for the appropriate
@@ -62,7 +62,7 @@ Lesson Program. It is added to The Carpentries
 supported lesson. The lesson is now considered **stable** and will remain in this stage for as long
 as it has active support from its Maintainer team.
 
-Lessons with grant support may be eligible for 
+Lessons with grant support may be eligible for
 support from The Carpentries staff in some or all of
 these stages. If you are pursuing grant funding for
 lesson development, please get in touch with us at
@@ -73,15 +73,18 @@ support.
 
 Before you start developing a new lesson, check
 to see if there are already people working on creating
-a lesson for this topic. The [Carpentries Incubator][incubator] is where our community comes
-together to talk about lesson ideas and find 
-collaborators. You can check existing [issues][issues] 
+a lesson for this topic.
+The [Carpentries Incubator][incubator] is where our community
+develops new curriculum together.
+New lessons are suggested for development and added to Incubator via the [Proposals][proposals] repository,
+so this is the best place to talk about lesson ideas and find collaborators.
+You can check existing [issues][issues] on that repository
 or start a new issue if you don't see any discussions
-on your topic. The [issue template][issue-template] has
+on your lesson topic. The [issue template][issue-template] has
 a short set of questions for you to answer. Your answers
 to these questions will help us to determine an
 appropriate next step for your lesson materials or
-idea. It's a good idea to also post to our 
+idea. It's a good idea to also post to our
 [discussion forum][discuss] and general [Slack channel][slack] to point interested people to your
 Incubator issue.
 
@@ -102,22 +105,22 @@ If The Carpentries have committed to develop a lesson
 on this topic (usually through grant funding), our
 Curriculum Team will work closely with you from
 pre-alpha through stable release, providing support on
-each step of the process. Your lesson will be 
-developed in one of the official Lesson Program GitHub 
-organisations. 
+each step of the process. Your lesson will be
+developed in one of the official Lesson Program GitHub
+organisations.
 
 ### Community Track
 
-If The Carpentries has not committed to develop a 
+If The Carpentries has not committed to develop a
 lesson on this topic, but the lesson is potentially of
 general interest to our community, the lesson authors
-will complete the development process independently. 
+will complete the development process independently.
 You will develop
 your lesson in the Carpentries Incubator and it will be
 made available through the Incubator
 website. If the lesson attracts a strong community
 of contributors, it will be considered for adoption
-as an official Carpentries lesson. 
+as an official Carpentries lesson.
 
 ### Carpentries Lab Track
 
@@ -132,15 +135,25 @@ as high-quality resources.
 ## Early development (pre-alpha through alpha)
 
 We will create a repository for you in the appropriate
-GitHub organization, using our 
+GitHub organization, using our
 [lesson template][lesson-template]. You will use the
 guidelines in the first five chapters of this handbook
-to develop your content. The Curriculum Team will 
+to develop your content. The Curriculum Team will
 be available to answer questions about the template
-and provide pedagogical guidance. For lessons on the 
-Official Track, authors will meet regularly with 
+and provide pedagogical guidance. For lessons on the
+Official Track, authors will meet regularly with
 a member of the Curriculum Team to work through the
 lesson drafting process.
+
+Lessons under community development in the Carpentries Incubator are
+[listed on The Carpentries website][community-lessons],
+based on topics added to the lesson repository.
+The Curriculum Team will support you in setting topics for your lesson.
+To help ensure consistency across our lesson repositories,
+please refer to [this listing][incubator-topics] of topics currently
+in use in The Carpentries Incubator,
+and re-use these values where appropriate,
+creating new topics where no pre-existing label exists for your lesson.
 
 ## Field testing: alpha stage
 
@@ -150,26 +163,26 @@ lesson is a good opportunity to receive and incorporate
 feedback from learners, instructors, and workshop
 helpers who can compare their expectations to
 reality. The initial feedback gathered during these first
-workshops is really important. 
+workshops is really important.
 
-During alpha pilot workshops, instructors and helpers should take detailed notes, including:  
-- amount of time used to teach each section  
-- amount of time used for each exercise  
-- technical issues that arose during installation  
-- bugs or parts of the lesson code that didn't work as expected  
-- incorrect or missing exercise solutions  
-- questions learners asked (and their answers)   
-- parts of the lesson that were confusing for learners  
+During alpha pilot workshops, instructors and helpers should take detailed notes, including:
+- amount of time used to teach each section
+- amount of time used for each exercise
+- technical issues that arose during installation
+- bugs or parts of the lesson code that didn't work as expected
+- incorrect or missing exercise solutions
+- questions learners asked (and their answers)
+- parts of the lesson that were confusing for learners
 
 These notes can be collected in an Etherpad, Google Doc, or other collaborative document that is shared
-with co-instructors and workshop helpers. This document should not be shared with workshop learners, 
-as it would add significantly to their cognitive load. 
+with co-instructors and workshop helpers. This document should not be shared with workshop learners,
+as it would add significantly to their cognitive load.
 
-After the workshop, instructors should share the notes document with the lesson authors - who 
+After the workshop, instructors should share the notes document with the lesson authors - who
 will convert the notes into individual issues in the lesson repo. For two-day workshops, lesson authors should expect
 to spend at least four hours to create follow-up issues, and at least
 eight hours to putting in PRs to fix these issues. For two pilot workshops, this translates
-to ~24 hours of work, which can be distributed among the lesson authors. 
+to ~24 hours of work, which can be distributed among the lesson authors.
 
 After incorporating workshop feedback, the lesson is
 now ready to be published. For lessons on the Official
@@ -179,22 +192,22 @@ may also choose to publish their lesson on Zenodo. At this stage, the lesson is 
 
 ## Polishing: beta stage
 
-Now that the lesson has been published, it is ready 
+Now that the lesson has been published, it is ready
 for teaching by instructors outside of the original
 authorship team, and for contributions from the broader
 Carpentries community. For lessons on the Official Track,
 Carpentries staff will assist lesson authors in recruiting instructors
 to teach beta pilots. Authors for non-Official Track lessons
-can recruit beta pilot hosts and instructors through our 
-[discussion list][discuss], [Slack organization][slack], 
+can recruit beta pilot hosts and instructors through our
+[discussion list][discuss], [Slack organization][slack],
 on Twitter, and through domain-specific mailing lists
-or other community groups they are part of. 
-For more information about the role played by 
-and qualifications needed to be a beta pilot instructors, see 
+or other community groups they are part of.
+For more information about the role played by
+and qualifications needed to be a beta pilot instructors, see
 our chapter on [community development roles][community-roles].
 
-The **beta stage** lasts approximately 6 months. During this time, members of 
-The Carpentries community can teach it and contribute to the content of the lesson. 
+The **beta stage** lasts approximately 6 months. During this time, members of
+The Carpentries community can teach it and contribute to the content of the lesson.
 The main goal of this phase of the lesson development is to develop the documentation
 needed to ensure that people who have not contributed to the initial development
 efforts of the lesson have enough information to teach it effectively.
@@ -202,56 +215,56 @@ efforts of the lesson have enough information to teach it effectively.
 Beta pilot instructors and helpers should take notes similar
 to those described above for alpha pilots, but should (hopefully!)
 notice fewer bugs and other issues. As with alpha pilots,
-beta pilot instructors will provide the lesson authors with 
+beta pilot instructors will provide the lesson authors with
 the notes they've collected during the workshop and the authors
-will convert those notes to issues and PRs to resolve concerns 
+will convert those notes to issues and PRs to resolve concerns
 raised during the workshop. Maintainers and other community members
-will be involved with this clean-up phase as well. 
+will be involved with this clean-up phase as well.
 
 After this polishing process, and a final check by a member of the
 Curriculum Team, your lesson will be published again on Zenodo,
-this time in its **stable state**. Official Track lessons will be added to 
+this time in its **stable state**. Official Track lessons will be added to
 the appropriate Lesson Program lessons page (e.g. [Data Carpentry's lessons page][dc-lessons])
 and to our [workshop request form][wkshp-request]. Anyone may now request a centrally-organized
-Carpentries workshop using this curriculum. 
+Carpentries workshop using this curriculum.
 
-For lessons on the CarpentriesLab track, authors will submit their stable stage lessons for review. 
+For lessons on the CarpentriesLab track, authors will submit their stable stage lessons for review.
 The CarpentriesLab Editor will select 2-3 reviewers within The Carpentries community with teaching experience and/o
 r appropriate domain expertise, who will provide an open and friendly review of the lesson.
 After incorporating feedback and comments from the reviewers, your lesson will be badged
-"Reviewed by the Carpentries Community" and will be listed on our websites as such. During this process, 
+"Reviewed by the Carpentries Community" and will be listed on our websites as such. During this process,
 you will have the possibility to include a short paper describing your
 lesson in the GitHub repository and have your lesson considered for publication in
 [JOSE](http://jose.theoj.org/), the Journal of Open Science Education.
-**This review process is in development and we are not yet accepting submissions. Please watch for 
-announcements as we roll out this program.** 
+**This review process is in development and we are not yet accepting submissions. Please watch for
+announcements as we roll out this program.**
 
 ## The stable lesson: Maintenance and lesson releases
 
-Congratulations! Your lesson has now been published and is being actively taught by the community. 
-That means you're done, right? Not exactly. In order to ensure that your wonderful lesson materials 
-continue to be relevant and useful, you'll need to build and train a team of lesson Maintainers, who 
-are responsible for day-to-day upkeep and periodic publication of the lesson. 
+Congratulations! Your lesson has now been published and is being actively taught by the community.
+That means you're done, right? Not exactly. In order to ensure that your wonderful lesson materials
+continue to be relevant and useful, you'll need to build and train a team of lesson Maintainers, who
+are responsible for day-to-day upkeep and periodic publication of the lesson.
 
-In a [previous chapter](community-development-roles#lesson-maintainers), we discussed the process for recruiting and training Maintainers. Here, we 
+In a [previous chapter](community-development-roles#lesson-maintainers), we discussed the process for recruiting and training Maintainers. Here, we
 will focus on the responsibilities of Maintainers, their day-to-day workflow, and their involvement
-in the lesson release process. 
+in the lesson release process.
 
-As your lesson is taught, workshop instructors and helpers will post issues and pull requests to 
-the lesson's GitHub repository. These will range from typo corrections, to installation problems, 
+As your lesson is taught, workshop instructors and helpers will post issues and pull requests to
+the lesson's GitHub repository. These will range from typo corrections, to installation problems,
 to recommendations for changing the libraries or function calls demonstrated in the lesson, and will
 therefore require different levels of consideration and technical expertise to implement. A typo
-correction will probably be taken care of independently by a single Maintainer, 
+correction will probably be taken care of independently by a single Maintainer,
 while a proposal to change
-the plotting system used in the lesson from matplotlib to seaborn will require significant 
-discussion. Each lesson Maintainer team will develop their own strategies for managing their work, 
-but we recommend the following as a starting point. 
+the plotting system used in the lesson from matplotlib to seaborn will require significant
+discussion. Each lesson Maintainer team will develop their own strategies for managing their work,
+but we recommend the following as a starting point.
 
 - Maintainers for a lesson should set a regular meeting to discuss any unresolved issues that have arisen and to decide on the division of responsibilities until
-their next meeting.  
+their next meeting.
 - One Maintainer commits to monitor the repo daily and respond to new issues and PRs to acknowledge them,
-thank the contributor, and apply appropriate [issue tags][issue-tags].  
-- Once a week, one Maintainer looks at the list of active issues and PRs and assigns each to one team member, based on the time commitment and availability discussed at that month's meeting.  
+thank the contributor, and apply appropriate [issue tags][issue-tags].
+- Once a week, one Maintainer looks at the list of active issues and PRs and assigns each to one team member, based on the time commitment and availability discussed at that month's meeting.
 - Individual team members work on resolving issues and PRs, as assigned, asking
 their co-Maintainers for review when needed.
 
@@ -261,19 +274,21 @@ to this section when they become available.**
 
 The above description focuses on Maintainers' ongoing duties. Maintainers are
 also involved with lesson releases, which take place roughly every six months.
-Information about lesson releases will be added to a future version of this 
-handbook. 
+Information about lesson releases will be added to a future version of this
+handbook.
 
+[community-lessons]: https://carpentries.org/community-lessons/
 [community-roles]: https://cdh.carpentries.org/community-development-roles.html#beta-pilot-instructors
 [discuss]: https://carpentries.topicbox.com/groups/discuss
 [dc-lessons]: https://datacarpentry.org/lessons/
-[incubator]: https://github.com/carpentries-incubator/proposals/blob/master/README.md
+[incubator]: https://github.com/carpentries-incubator/
+[incubator-topics]: https://docs.google.com/spreadsheets/d/1KkmBtCu4PaNb5nzJAD82UHcfHQlaPY84qPVxw8WO8es/edit?usp=sharing
 [issues]: https://github.com/carpentries-incubator/proposals/issues
 [issue-tags]: https://docs.carpentries.org/topic_folders/maintainers/github_labels.html
 [issue-template]: https://github.com/carpentries-incubator/proposals/blob/master/ISSUE_TEMPLATE.md
 [lesson-programs]: https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html
 [lesson-template]: https://github.com/carpentries/styles
+[proposals]: https://github.com/carpentries-incubator/proposals/blob/master/README.md
 [slack]: https://swc-slack-invite.herokuapp.com/
 [wkshp-request]: http://carpentries.org/request-workshop
 [zenodo]: https://zenodo.org/communities/carpentries/?page=1&size=20
-

--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -148,31 +148,23 @@ lesson drafting process.
 Lessons under community development in the Carpentries Incubator are
 [listed on The Carpentries website][community-lessons],
 based on topics added to the lesson repository.
-Some topics are essential:
-labeling the repository as a lesson,
-noting the language(s) the material is available in,
-and describing the lesson's location and state of development.
-Others are more flexible,
-but should describe the domain of the lesson
-(e.g. microbial ecology, digital humanities),
-the main skills taught in the lesson
-(e.g. data organization, image segmentation),
-and the main software/tools used in the lesson
-(e.g. Python, Singularity).
-The Curriculum Team will support you in setting topics for your lesson.
+Some topics are essential, while others are more flexible.
 See the table below for guidance about the types and number of topics each
 lesson repository should have.
 
 | category | example | number | description |
 |----------|----------|--------|------|
-| lesson | `lesson` | 1 | the type of repo. this needs to be `lesson` for the lesson to be listed on the Community Developed Lessons page |
-| location | `carpentries-incubator` | 1 | `carpentries-incubator` or `carpentrieslab` |
-| language | `español` | >0 | the language(s) the lesson is available in. should be present for every lesson repo |
-| stage | `alpha` | 1 | the current development stage for the lesson. See [chapter 7 of the curriculum development handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html) for more info. |
-| domain | `microbial-ecology` | 1-2 | the high-level domain(s) of the lesson, for a general categorisation |
-| tools | `python` | 1-3 | the tool(s) taught in the lesson |
-| skills | `taxonomic-classification` | 1-3 | the main skill(s) taught in the lesson |
+| lesson* | `lesson` | 1 | Must be `lesson` to be listed on the Community Developed Lessons page. |
+| location* | `carpentries-incubator` | 1 | `carpentries-incubator` or `carpentrieslab`. |
+| language* | `español` | >0 | The language(s) the lesson is available in. |
+| stage* | `alpha` | 1 | The current development stage for the lesson. Read on for more info. |
+| domain | `microbial-ecology` | 1-2 | The high-level domain(s) of the lesson, for a general categorization. |
+| tools | `python` | 1-3 | The main tool(s) taught in the lesson. |
+| skills | `taxonomic-classification` | 1-3 | The main skill(s) taught in the lesson. |
 
+_Categories marked with an asterisk (*) are essential._
+
+The Curriculum Team will support you in setting topics for your lesson.
 To help ensure consistency across our lesson repositories,
 please refer to [this listing][incubator-topics] of topics currently
 in use in The Carpentries Incubator,

--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -152,17 +152,17 @@ Some topics are essential, while others are more flexible.
 See the table below for guidance about the types and number of topics each
 lesson repository should have.
 
-| category | example | number | description |
+| Category | Example | Number | Description |
 |----------|----------|--------|------|
-| lesson* | `lesson` | 1 | Must be `lesson` to be listed on the Community Developed Lessons page. |
-| location* | `carpentries-incubator` | 1 | `carpentries-incubator` or `carpentrieslab`. |
-| language* | `español` | >0 | The language(s) the lesson is available in. |
-| stage* | `alpha` | 1 | The current development stage for the lesson. Read on for more info. |
-| domain | `microbial-ecology` | 1-2 | The high-level domain(s) of the lesson, for a general categorization. |
-| tools | `python` | 1-3 | The main tool(s) taught in the lesson. |
-| skills | `taxonomic-classification` | 1-3 | The main skill(s) taught in the lesson. |
+| Lesson* | `lesson` | 1 | Must be `lesson` to be listed on the Community Developed Lessons page. |
+| Location* | `carpentries-incubator` | 1 | `carpentries-incubator` or `carpentrieslab`. |
+| Language* | `español` | >0 | The language(s) the lesson is available in. |
+| Stage* | `alpha` | 1 | The current development stage for the lesson. Read on for more info. |
+| Domain | `microbial-ecology` | 1-2 | The high-level domain(s) of the lesson, for a general categorization. |
+| Tools | `python` | 1-3 | The main tool(s) taught in the lesson. |
+| Skills | `taxonomic-classification` | 1-3 | The main skill(s) taught in the lesson. |
 
-_Categories marked with an asterisk (*) are essential._
+*Categories marked with an asterisk (\*) are essential.*
 
 The Curriculum Team will support you in setting topics for your lesson.
 To help ensure consistency across our lesson repositories,

--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -75,8 +75,8 @@ Before you start developing a new lesson, check
 to see if there are already people working on creating
 a lesson for this topic.
 The [Carpentries Incubator][incubator] is where our community
-develops new curriculum together.
-New lessons are suggested for development and added to Incubator via the [Proposals][proposals] repository,
+develops new curricula together.
+New lessons are suggested for development and added to the Incubator via the [Proposals][proposals] repository,
 so this is the best place to talk about lesson ideas and find collaborators.
 You can check existing [issues][issues] on that repository
 or start a new issue if you don't see any discussions
@@ -135,7 +135,7 @@ as high-quality resources.
 ## Early development (pre-alpha through alpha)
 
 We will create a repository for you in the appropriate
-GitHub organization, using our
+GitHub organization, using The Carpentries
 [lesson template][lesson-template]. You will use the
 guidelines in the first five chapters of this handbook
 to develop your content. The Curriculum Team will
@@ -147,9 +147,10 @@ lesson drafting process.
 
 Lessons under community development in the Carpentries Incubator are
 [listed on The Carpentries website][community-lessons],
-based on topics added to the lesson repository.
-Some topics are essential, while others are more flexible.
-See the table below for guidance about the types and number of topics each
+based on metadata describing the lesson.
+This metadata is added in the form of topic tags on the lesson repository.
+Some of these topic tags are essential, while others are more flexible.
+See the table below for guidance about the types and number of topic tags each
 lesson repository should have.
 
 | Category | Example | Number | Description |
@@ -162,14 +163,15 @@ lesson repository should have.
 | Tools | `python` | 1-3 | The main tool(s) taught in the lesson. |
 | Skills | `taxonomic-classification` | 1-3 | The main skill(s) taught in the lesson. |
 
-*Categories marked with an asterisk (\*) are essential.*
+*Categories marked with an asterisk (\*) are required in order for a lesson to appear and be appropriately sorted on the Community Developed Lessons page.*
 
-The Curriculum Team will support you in setting topics for your lesson.
-To help ensure consistency across our lesson repositories,
-please refer to [this listing][incubator-topics] of topics currently
+The Curriculum Team will support you in setting appropriate topic tags for your lesson.
+To help ensure consistency across all lesson repositories
+developed by The Carpentires community,
+please refer to [this listing][incubator-topics] of topic tags currently
 in use in The Carpentries Incubator,
 and re-use these values where appropriate,
-creating new topics where no pre-existing label exists for your lesson.
+creating new topic tags where no pre-existing label exists for your lesson.
 
 ## Field testing: alpha stage
 

--- a/07-lesson-life-cycle.Rmd
+++ b/07-lesson-life-cycle.Rmd
@@ -148,7 +148,31 @@ lesson drafting process.
 Lessons under community development in the Carpentries Incubator are
 [listed on The Carpentries website][community-lessons],
 based on topics added to the lesson repository.
+Some topics are essential:
+labeling the repository as a lesson,
+noting the language(s) the material is available in,
+and describing the lesson's location and state of development.
+Others are more flexible,
+but should describe the domain of the lesson
+(e.g. microbial ecology, digital humanities),
+the main skills taught in the lesson
+(e.g. data organization, image segmentation),
+and the main software/tools used in the lesson
+(e.g. Python, Singularity).
 The Curriculum Team will support you in setting topics for your lesson.
+See the table below for guidance about the types and number of topics each
+lesson repository should have.
+
+| category | example | number | description |
+|----------|----------|--------|------|
+| lesson | `lesson` | 1 | the type of repo. this needs to be `lesson` for the lesson to be listed on the Community Developed Lessons page |
+| location | `carpentries-incubator` | 1 | `carpentries-incubator` or `carpentrieslab` |
+| language | `español` | >0 | the language(s) the lesson is available in. should be present for every lesson repo |
+| stage | `alpha` | 1 | the current development stage for the lesson. See [chapter 7 of the curriculum development handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html) for more info. |
+| domain | `microbial-ecology` | 1-2 | the high-level domain(s) of the lesson, for a general categorisation |
+| tools | `python` | 1-3 | the tool(s) taught in the lesson |
+| skills | `taxonomic-classification` | 1-3 | the main skill(s) taught in the lesson |
+
 To help ensure consistency across our lesson repositories,
 please refer to [this listing][incubator-topics] of topics currently
 in use in The Carpentries Incubator,


### PR DESCRIPTION
Introducing some information about lesson repository topics for Incubator repos, and linking to the sheet of all topics currently in use across the Incubator.

Not sure if this is the best place to be adding this information, so please advise if you think it's a better fit somewhere else.