### PR TITLE
Instructions for converting existing lessons

### DIFF
--- a/A2-converting-existing-lessons.Rmd
+++ b/A2-converting-existing-lessons.Rmd
@@ -1,0 +1,188 @@
+# Adapting Existing Lessons for The Carpentries
+
+A guide for those wishing to adapt existing lesson materials,
+written/published in formats other than The Carpentries lesson template,
+to conform to the requirements for inclusion in a Carpentries lesson program
+or The Carpentries Incubator.
+
+## Lesson Template
+
+Below are some suggested approaches to incorporate previously-written
+lesson content into The Carpentries lesson template.
+Unfortunately we cannot provide detailed instructions or automated conversion
+for content in every format,
+but this section includes suggested workflows to adapt content in several
+of the most common formats for lessons teaching software and data skills.
+
+## Conversion from Jupyter
+
+Jupyter notebooks in `.ipynb` format can be converted to Markdown via
+_File_ -> _Download as_ -> _Markdown (.md)_ in the graphical Notebooks interface
+or by using [the `nbconvert` command line tool](https://nbconvert.readthedocs.io/en/latest/).
+
+[The `convert.py` Python script](https://github.com/datacarpentry/astronomy-python/blob/gh-pages/_episodes/convert.py),
+written by [Allen Downey](https://www.allendowney.com/wp/) while developing the
+[Data Carpentry Astronomy curriculum](https://datacarpentry.github.io/astronomy-python),
+processes Jupyter Notebooks such that, afterwards,
+the Markdown derived from them
+can be more readily incorporated into The Carpentries Lesson Template.
+The script makes some assumptions about what your Jupyter notebooks will look like
+(e.g. it looks for third-level headings beginning "Exercise" to define exercise blocks),
+but it may save you some time if you have a large number of notebooks containing
+a lot of code blocks etc.
+
+To be rendered as episodes of a lesson site,
+the resulting Markdown generated from the `.ipynb` files processed by `convert.py`
+will need to have YAML front matter added, before being placed into the `_episodes` directory of a lesson repository (see [Markdown](#markdown) below).
+
+## Conversion from RMarkdown
+
+Lesson content written with RMarkdown can be directly included in the lesson template, by adding RMarkdown episodes to the `_episodes_rmd` directory.
+
+[The _Using Rmarkdown_ episode of the Lesson Example](https://carpentries.github.io/lesson-example/05-rmarkdown-example/)
+provides more details of how to write episodes in RMarkdown.
+Briefly, the important points are:
+
+1. You must add the episode front matter just as you would for standard
+   Markdown (see below).
+2. You should commit your RMarkdown files to the `main` branch.
+   The lesson build workflows have been configured such that
+   any RMarkdown files commited to the `_episodes_rmd` directory
+   in the `main` branch of the GitHub lesson repository
+   will be converted to standard Markdown and copied to
+   the `_episodes` directory of the `gh-pages` branch,
+   where the content will be served by GitHub Pages.
+3. You should use the `fig.alt` parameter to define the alternative text
+   property for any figures/images created by code chunks in your RMarkdown.
+4. You will need to write the lesson landing page (`index.md`),
+   installation/setup instructions (`setup.md`),
+   Instructor Notes (`guide.md`),
+   and glossary/reference guide (`reference.md`)
+   in standard Markdown.
+
+## Conversion from other formats
+
+[Pandoc](https://pandoc.org/) is a universal format conversion tool,
+which may be able to help when converting other formats
+(e.g. ReStructured Text) to Markdown.
+
+## Markdown
+
+Whether you have lesson content already in Markdown (e.g. from GitBook)
+or converted to Markdown from a Jupyter Notebook or any other format,
+there are some additional steps you will need to take to make this content
+compatible with the lesosn template:
+
+### Set up a lesson repository
+
+For lessons in [The Carpentries Incubator](https://cdh.carpentries.org/the-lesson-life-cycle.html#where-to-start):
+submit a new issue to
+[the Incubator Proposals repository](https://github.com/carpentries-incubator/proposals)
+to request a new lesson repository.
+You will receive full administrative access to a "blank slate" lesson repository
+with some brief instructions to help you get started.
+
+For lessons being developed outside The Carpentries Incubator:
+follow [the setup instructions in the Lesson Example](https://carpentries.github.io/lesson-example/setup.html).
+
+**A note about the license and code of conduct**:
+[Carpentries lessons use the Creative Commons Attribution version 4.0 (CC-BY) license for lesson material, and the MIT license for any example code included in the lesson](https://github.com/carpentries-incubator/jekyll-pages-novice/blob/gh-pages/LICENSE.md).
+Laws vary from country to country but,
+as a general rule,
+**changing the license of a project requires explicit agreement**
+**from all previous contributors to the repository**.
+You should make sure that you have done this before you transfer the material
+into the lesson repository (which already includes the license file),
+or clearly state that you are re-using material originally created elsewhere
+(if the license of the existing material allows this).
+Similarly, **we require that all lessons follow [our Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)**,
+and you should make sure that you and all your collaborators have read and
+understand this document, and that your existing lesson material complies with
+the policies described in it, before you begin working in the new repository.
+
+### Add YAML Front Matter
+
+The Jekyll engine that renders sites on GitHub Pages
+identifies Markdown files to build into webpages based on the presence of
+[a header section](https://carpentries.github.io/lesson-example/04-formatting/index.html#episode-header),
+known as [_front matter_](https://jekyllrb.com/docs/front-matter/), at the top of the file.
+[The _Technological Introductions_ chapter](https://cdh.carpentries.org/technological-introductions.html#episode-files)
+details the fields that must be present in this YAML header.
+Note: episode files written in RMarkdown must include an additional line,
+`source: Rmd`, to be rendered correctly.
+
+If your lesson already includes statements of learning objectives/outcomes,
+questions, and/or key points for each section,
+this information should be transferred to the YAML header
+for the respective episodes.
+
+### Add _alt_ Text to Images
+
+To increase the accessibility of Carpentries lessons,
+all images should include a short, descriptive _alternative text_ property.
+In Markdown, alternative text is added between the `[]` of the
+image definition, i.e.
+
+`![Image alt text](path/to/image/file.svg)`
+
+Accessibility consultants Deque provide
+[a good overview of the important things to consider when writing alternative text](https://www.deque.com/blog/great-alt-text-introduction/).
+
+### Add to `_episodes`
+
+To be built by Jekyll and included in the navigation of the resulting lesson site,
+Markdown files with front matter should be added to the `_episodes` directory of
+your lesson repository.
+Other files needed for a lesson, but not located in the `_episodes` directory,
+include the lesson landing page (`index.md`),
+the installation/setup instructions (`setup.md`),
+Instructor Notes as an aid to those teaching the lesson (`guide.md`),
+and the glossary/reference guide (`reference.md`).
+You can find more complete information about these files, and others included in
+the lesson template, in [the _Lesson Organization_ episode of the Lesson Example](https://carpentries.github.io/lesson-example/03-organization/index.html#starter-files).
+
+### Organise supporting files
+
+Images used as figures in the lesson should be stored in the `fig` directory,
+example code in the `code` directory,
+and example data in `data`.
+Any other supporting files that do not fit into the previous three categories
+can be placed in `files`.
+Remember to adjust any internal links in your lesson to match the new locations
+of these files.
+
+### Implement formatted blocks
+
+Some of the key visual elements of a Carpentries lesson are the
+boxes used for callouts, lesson prerequisites, exercises, solutions, etc.
+You should add the appropriate formatting to any relevant parts of your
+lesson, so that they render correctly.
+Generally speaking, this involves converting these to blockquotes followed
+by a tag that applies a CSS class to the preceding block.
+
+See [the _Formatting_ episode of the Lesson Example](https://carpentries.github.io/lesson-example/04-formatting/index.html#special-blockquotes)
+for details and examples.
+That page also includes more information about the best way to display
+code blocks in the lesson template.
+
+### (Recommended) Centralise Link References
+
+To reduce the effort associated with modifying the target URLs of
+links in your lesson if/when they change,
+you can collect all these target URLs as Markdown link references,
+in the format `[link-ref]: https://carpentries.org`,
+in the `_includes/links.md` file of the lesson repository.
+
+You can then refer to these with the syntax `[link text][link-ref]`
+after adding `{% include links.md %} to the very bottom of the page content.
+
+### Complete Lesson Repository Setup
+
+To finish setting up your lesson repository
+
+- fill in any fields marked "FIXME" in the lesson `README.md` and/or `_config.yml`
+- list the names of current and past maintainers in the lesson `README.md`
+- update the `AUTHORS` and `CITATION` files in the lesson repository
+- add the lesson URL and 
+  [topic tags](https://cdh.carpentries.org/the-carpentries-incubator.html#topic-tags)
+  to the _Description_ of your lesson repository on GitHub

--- a/A2-converting-existing-lessons.Rmd
+++ b/A2-converting-existing-lessons.Rmd
@@ -20,8 +20,8 @@ Jupyter notebooks in `.ipynb` format can be converted to Markdown via
 _File_ -> _Download as_ -> _Markdown (.md)_ in the graphical Notebooks interface
 or by using [the `nbconvert` command line tool](https://nbconvert.readthedocs.io/en/latest/).
 
-[The `convert.py` Python script](https://github.com/datacarpentry/astronomy-python/blob/gh-pages/_episodes/convert.py),
-written by [Allen Downey](https://www.allendowney.com/wp/) while developing the
+[The `convert_ipynb.py` Python script](utils/convert_ipynb.py),
+based on the `convert.py` script written by [Allen Downey](https://www.allendowney.com/wp/) while developing the
 [Data Carpentry Astronomy curriculum](https://datacarpentry.github.io/astronomy-python),
 processes Jupyter Notebooks such that, afterwards,
 the Markdown derived from them
@@ -32,8 +32,8 @@ but it may save you some time if you have a large number of notebooks containing
 a lot of code blocks etc.
 
 To be rendered as episodes of a lesson site,
-the resulting Markdown generated from the `.ipynb` files processed by `convert.py`
-will need to have YAML front matter added, before being placed into the `_episodes` directory of a lesson repository (see [Markdown](#markdown) below).
+the resulting Markdown generated from the `.ipynb` files processed by `convert_ipynb.py`
+will need to have [YAML front matter](#add-yaml-front-matter) added, before being placed in the `_episodes` directory of a lesson repository (see [Markdown](#markdown) below).
 
 ## Conversion from RMarkdown
 
@@ -43,8 +43,8 @@ Lesson content written with RMarkdown can be directly included in the lesson tem
 provides more details of how to write episodes in RMarkdown.
 Briefly, the important points are:
 
-1. You must add the episode front matter just as you would for standard
-   Markdown (see below).
+1. You must [add the episode front matter](#add-yaml-front-matter)
+   just as you would for standard Markdown.
 2. You should commit your RMarkdown files to the `main` branch.
    The lesson build workflows have been configured such that
    any RMarkdown files commited to the `_episodes_rmd` directory
@@ -71,32 +71,35 @@ which may be able to help when converting other formats
 Whether you have lesson content already in Markdown (e.g. from GitBook)
 or converted to Markdown from a Jupyter Notebook or any other format,
 there are some additional steps you will need to take to make this content
-compatible with the lesosn template:
+compatible with the lesson template:
 
 ### Set up a lesson repository
 
-For lessons in [The Carpentries Incubator](https://cdh.carpentries.org/the-lesson-life-cycle.html#where-to-start):
-submit a new issue to
+For lessons being submitted to [The Carpentries Incubator](https://cdh.carpentries.org/the-lesson-life-cycle.html#where-to-start):
+create a new issue to
 [the Incubator Proposals repository](https://github.com/carpentries-incubator/proposals)
 to request a new lesson repository.
-You will receive full administrative access to a "blank slate" lesson repository
+After accepting an invitation, sent by email,
+to join the `carpentries-incubator` organisation,
+you will receive full administrative access to a new lesson repository
 with some brief instructions to help you get started.
 
 For lessons being developed outside The Carpentries Incubator:
 follow [the setup instructions in the Lesson Example](https://carpentries.github.io/lesson-example/setup.html).
 
 **A note about the license and code of conduct**:
-[Carpentries lessons use the Creative Commons Attribution version 4.0 (CC-BY) license for lesson material, and the MIT license for any example code included in the lesson](https://github.com/carpentries-incubator/jekyll-pages-novice/blob/gh-pages/LICENSE.md).
+[Carpentries lessons use the Creative Commons Attribution version 4.0 (CC-BY) license for lesson material, and the MIT license for any software and example code included in the lesson repository](https://github.com/carpentries/styles/blob/gh-pages/LICENSE.md).
 Laws vary from country to country but,
 as a general rule,
 **changing the license of a project requires explicit agreement**
 **from all previous contributors to the repository**.
-You should make sure that you have done this before you transfer the material
+You should make sure that you have obtained this agreement
+before you transfer the material
 into the lesson repository (which already includes the license file),
 or clearly state that you are re-using material originally created elsewhere
 (if the license of the existing material allows this).
 Similarly, **we require that all lessons follow [our Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)**,
-and you should make sure that you and all your collaborators have read and
+and you should make sure that you and all of your collaborators have read and
 understand this document, and that your existing lesson material complies with
 the policies described in it, before you begin working in the new repository.
 
@@ -105,7 +108,8 @@ the policies described in it, before you begin working in the new repository.
 The Jekyll engine that renders sites on GitHub Pages
 identifies Markdown files to build into webpages based on the presence of
 [a header section](https://carpentries.github.io/lesson-example/04-formatting/index.html#episode-header),
-known as [_front matter_](https://jekyllrb.com/docs/front-matter/), at the top of the file.
+known as [_front matter_](https://jekyllrb.com/docs/front-matter/),
+which is located at the top of the file.
 [The _Technological Introductions_ chapter](https://cdh.carpentries.org/technological-introductions.html#episode-files)
 details the fields that must be present in this YAML header.
 Note: episode files written in RMarkdown must include an additional line,
@@ -120,18 +124,21 @@ for the respective episodes.
 
 To increase the accessibility of Carpentries lessons,
 all images should include a short, descriptive _alternative text_ property.
-In Markdown, alternative text is added between the `[]` of the
+In Markdown, alternative text (alt text) is added between the `[]` of the
 image definition, i.e.
 
 `![Image alt text](path/to/image/file.svg)`
 
 Accessibility consultants Deque provide
-[a good overview of the important things to consider when writing alternative text](https://www.deque.com/blog/great-alt-text-introduction/).
+[a good overview of the important things to consider when writing alt text](https://www.deque.com/blog/great-alt-text-introduction/),
+and a Medium post from [Amy Cesal](https://twitter.com/AmyCesal) gives
+[guidance on alt text for data visualisations](https://medium.com/nightingale/writing-alt-text-for-data-visualization-2a218ef43f81).
+
 
 ### Add to `_episodes`
 
 To be built by Jekyll and included in the navigation of the resulting lesson site,
-Markdown files with front matter should be added to the `_episodes` directory of
+Markdown files with front matter should be located in the `_episodes` directory of
 your lesson repository.
 Other files needed for a lesson, but not located in the `_episodes` directory,
 include the lesson landing page (`index.md`),
@@ -157,8 +164,8 @@ Some of the key visual elements of a Carpentries lesson are the
 boxes used for callouts, lesson prerequisites, exercises, solutions, etc.
 You should add the appropriate formatting to any relevant parts of your
 lesson, so that they render correctly.
-Generally speaking, this involves converting these to blockquotes followed
-by a tag that applies a CSS class to the preceding block.
+Generally speaking, this involves converting these elements to blockquotes
+followed by a tag that applies a CSS class to the preceding block.
 
 See [the _Formatting_ episode of the Lesson Example](https://carpentries.github.io/lesson-example/04-formatting/index.html#special-blockquotes)
 for details and examples.
@@ -174,7 +181,7 @@ in the format `[link-ref]: https://carpentries.org`,
 in the `_includes/links.md` file of the lesson repository.
 
 You can then refer to these with the syntax `[link text][link-ref]`
-after adding `{% include links.md %} to the very bottom of the page content.
+after adding `{% include links.md %}` to the very bottom of the page content.
 
 ### Complete Lesson Repository Setup
 
@@ -183,6 +190,6 @@ To finish setting up your lesson repository
 - fill in any fields marked "FIXME" in the lesson `README.md` and/or `_config.yml`
 - list the names of current and past maintainers in the lesson `README.md`
 - update the `AUTHORS` and `CITATION` files in the lesson repository
-- add the lesson URL and 
+- add the lesson URL and
   [topic tags](https://cdh.carpentries.org/the-carpentries-incubator.html#topic-tags)
   to the _Description_ of your lesson repository on GitHub

--- a/utils/convert_ipynb.py
+++ b/utils/convert_ipynb.py
@@ -1,0 +1,134 @@
+'''
+Based on the original convert.py script written by
+Allen Downey (https://www.allendowney.com/wp/)
+for use when developing the Data Carpentry Astronomy curriculum
+(https://github.com/datacarpentry/astronomy-python/blob/gh-pages/_episodes/convert.py).
+
+Run this script in the folder containing the Jupyter notebook files
+for your lesson.
+'''
+
+import nbformat as nbf
+from glob import glob
+#from pypandoc import convert_text
+import re
+from textwrap import wrap
+
+# Collect a list of all notebooks in the content folder
+notebooks = glob("*.ipynb")
+
+# Text to look for in adding tags
+tag_search_dict = {
+    "remove-cell": "#hide\n",
+    "hide-cell": "#hide\n",
+    "remove-input": "#hide_input\n",
+    "hide-input": "#hide_input\n",
+    "remove-output": "#hide_output\n",
+    "hide-output": "#hide_output\n",
+}
+
+WRAP_OPTIONS = dict(break_long_words=False,
+                    break_on_hyphens=False)
+
+def wrap_source(source):
+    res = []
+    for line in source.split('\n'):
+        if len(line) > 80:
+            line = '\n'.join(wrap(line, **WRAP_OPTIONS))
+        res.append(line)
+    return '\n'.join(res)
+
+def remove_first_line(text):
+    _, _, rest = text.partition('\n')
+    return rest
+
+def indent_text(text, prefix):
+    res = []
+    for line in text.split('\n'):
+        res.append(prefix + line + '\n')
+    return ''.join(res)
+
+def format_exercise(cell):
+    res = []
+    res.append('> ## Exercise\n')
+    text = remove_first_line(cell['source'])
+    res.append(indent_text(text, '> '))
+    return ''.join(res)
+
+
+def process_markdown(cell):
+    if cell['source'].startswith('### Exercise'):
+        cell['source'] = format_exercise(cell)
+    else:
+        cell['source'] = re.sub('\n>', '\n> :', cell['source'])
+    cell['source'] = wrap_source(cell['source'])
+
+
+def process_code(cell):
+    """Translate code blocks
+    """
+    text = cell['source']
+
+    # If it's a solution, remove the first line
+    is_solution = text.startswith('# Solution')
+    if is_solution:
+        text = remove_first_line(text)
+
+    # Assemble the exercise formatting
+    cell['cell_type'] = 'raw'
+    res = []
+    res.append('\n~~~')
+    res.append(text)
+    res.append('~~~')
+    res.append('{: .language-python}')
+
+    if cell['outputs']:
+        res.append('\n~~~')
+        for output in cell['outputs']:
+            try:
+                res.append(output['text'])
+            except KeyError:
+                """Ignoring non-text output"""
+                pass
+        res.append('~~~')
+        res.append('{: .output}\n')
+
+    cell['source'] = '\n'.join(res)
+
+    # If it's a solution, indent it and add the suffix
+    if is_solution:
+        cell['source'] = indent_text(cell['source'], '> > ')
+        cell['source'] += '> {: .solution}\n'
+        cell['source'] += '{: .challenge}\n'
+
+def process_cell(cell):
+    if cell['cell_type'] == 'raw':
+        return
+
+    cell_tags = cell.get('metadata', {}).get('tags', [])
+    if 'remove-cell' in cell_tags:
+        cell['cell_type'] = 'raw'
+        cell['source'] = ''
+        cell['outputs'] = []
+        return
+
+    if cell['cell_type'] == 'markdown':
+        process_markdown(cell)
+
+    if cell['cell_type'] == 'code':
+        process_code(cell)
+
+def process_notebook(path):
+    """
+    """
+    ntbk = nbf.read(path, nbf.NO_CONVERT)
+
+    for cell in ntbk.cells:
+        process_cell(cell)
+
+    nbf.write(ntbk, path)
+
+# Search through each notebook and look for the text, add a tag if necessary
+for path in notebooks:
+    print('converting', path)
+    process_notebook(path)


### PR DESCRIPTION
Introduces a new appendix to the handbook, describing how existing lessons in other formats can be adapted to The Carpentries. Instructions are limited to Jupyter notebooks and RMarkdown for now, one link to Pandoc notwithstanding.