### PR TITLE
Add link to carpentries/maintainer-resources repo + typos.

### DIFF
--- a/06-community-development-roles.Rmd
+++ b/06-community-development-roles.Rmd
@@ -6,7 +6,7 @@ and background knowledge. Lessons should also be appropriate for
 learners at different institutions, and not require specialized
 local or institutional knowledge. Our lessons attain this
 broad usability by virtue of being the product of many people
-at differnt institutions around the world who work together
+at different institutions around the world who work together
 in different roles to create, test, and iteratively improve and
 update lesson materials.
 
@@ -85,19 +85,19 @@ lesson materials and/or experience working with GitHub and the [other technologi
 we use to create and host our lessons][Technological Introductions]. Each
 lesson will have at least two Maintainers, and it's ok for one Maintainer
 to have domain experience and another to be more comfortable with the technical
-aspects of lesson maintainence.
+aspects of lesson maintenance.
 
 ### Maintainer recruitment, requirements and time commitment
 
 It's a good idea to recruit at least four Maintainers per lesson, as our
-community members are volunteers and may have fluxuating levels of time to
+community members are volunteers and may have fluctuating levels of time to
 commit to this role. Having a larger team of Maintainers ensures you'll
 always have
 at least one or two active Maintainers at any given time.
 
 Maintainers commit to a [specific set of duties][maintainer-guidelines], and
 go through a short onboarding process to familiarise them with the social,
-technological, and curriculum-specific elements of lesson maintanence.
+technological, and curriculum-specific elements of lesson maintenance.
 This onboarding is available as a [written curriculum][maintainer-onboarding-lesson]
 and in future may be made available as a video recording, however, if
 time allows, we recommend running onboarding for your Maintainer group via
@@ -111,6 +111,7 @@ Once your Maintainers have been onboarded, they will join The Carpentries
 full [Maintainer team][maintainer-team]. This team meets monthly to share
 skills, exchange ideas, and get suggestions from each other around
 challenging issues and pull requests in their individual lesson repositories.
+The minutes for these meetings are stored in the [Maintainer Resources repository][maintainer-resources].
 Meeting times and information about how to stay in touch with the Maintainer
 team is available in [The Carpentries Handbook][maintainer-stay-in-touch].
 
@@ -149,7 +150,7 @@ discuss and make decisions about proposed large-scale
 changes to the lessons within their curriculum. These proposals may be initiated
 by community members, including Maintainers, or by members of the CAC. The CAC
 communicates their recommendations back to the Lesson Maintainers and provides
-consulation and support to Maintainers in implementing proposed changes.
+consulting and support to Maintainers in implementing proposed changes.
 
 Ideally, a Curriculum Advisory Committee should be assembled in the initial
 stages of lesson development, before materials start to be drafted. The CAC
@@ -225,6 +226,7 @@ touch with team@carpentries.org.
 [maintainer-guidelines]: https://docs.carpentries.org/topic_folders/maintainers/maintainers.html#maintainer-guidelines
 [maintainer-onboarding-lesson]: https://carpentries.github.io/maintainer-onboarding/
 [maintainer-onboarding-process]: https://docs.carpentries.org/topic_folders/maintainers/maintainers.html#maintainer-onboarding
+[maintainer-resources]: https://github.com/carpentries/maintainer-resources
 [maintainer-team]: https://carpentries.org/maintainers/
 [maintainer-stay-in-touch]: https://docs.carpentries.org/topic_folders/maintainers/maintainers.html#how-to-stay-in-touch
 [onboarding-playlist]: https://www.youtube.com/watch?v=zgdutO5tejo&list=PLXLapl_LKb4e73Vf2e3rS2q2TDJ7oh_DX


### PR DESCRIPTION
Hi,

During the last Maintainers Coworking Meeting, I learned about the [carpentries/maintainer-resources](https://github.com/carpentries/maintainer-resources) repository. I could not find any mentions of this repository since it's quite recent, so I thought it would be useful to add a link to it in Chapter 6 of this handbook.

I wasn't sure on the build process for rendering the book, so I kept my changes only to the .Rmd file.

Thank you for any assistance you can provide.

Best,
V