### PR TITLE
Add handbook retirement notice

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -11,6 +11,8 @@ bookdown::gitbook:
     edit: https://github.com/carpentries/curriculum-development/edit/master/%s
     view: https://github.com/carpentries/curriculum-development/blob/master/%s
     download: ["pdf", "epub"]
+  includes:
+    before_body: handbook-retirement-notice.html
 bookdown::pdf_book:
   includes:
     in_header: preamble.tex

--- a/handbook-retirement-notice.html
+++ b/handbook-retirement-notice.html
@@ -1,0 +1,5 @@
+<div style="color: #383838; background-color: #FDEAF2; padding: 5px">
+<p>
+<strong>The Carpentries is preparing to retire this handbook at the end of 2023.</strong> Existing content that has not already been replicated elsewhere will be relocated. <a href="https://github.com/carpentries/curriculum-development/issues/81">See the relevant issue on the source repository for more details.</a>
+</p>
+</div>


### PR DESCRIPTION
As suggested by @bencomp, this adds a prominent notice to the top of every page in the handbook, alerting visitors to the planned retirement of the resource and directing them towards #81 where they can learn more.