### PR TITLE
fix r-lib actions branch

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
 
       - name: Install pandoc and pandoc citeproc
         uses: r-lib/actions/setup-pandoc@v1


### PR DESCRIPTION
The GH action on this repo has been failing.  I **think** it is because of the r-lib actions branch name.  See https://github.com/r-lib/actions
